### PR TITLE
Add @jsonIgnoreNull to support ignoring properties with null values

### DIFF
--- a/lib/jsonx.dart
+++ b/lib/jsonx.dart
@@ -15,6 +15,10 @@ class _JsonIgnore {
   const _JsonIgnore();
 }
 
+class _JsonIgnoreNull {
+  const _JsonIgnoreNull();
+}
+
 class _JsonProperty {
   const _JsonProperty();
 }
@@ -34,6 +38,13 @@ const Object jsonObject = const _JsonObject();
  * annotated with '@jsonObject'.
  */
 const Object jsonIgnore = const _JsonIgnore();
+
+/**
+ * Marking a field or property with the annotation '@jsonIgnoreNull' instructs
+ * the jsonx encoder not to encode that field or property if the value is equal
+ * to 'null'.
+ */
+const Object jsonIgnoreNull = const _JsonIgnoreNull();
 
 /**
  * Marking a field or property with the annotation '@jsonProperty' instructs the
@@ -394,6 +405,7 @@ __objectToJson(object) {
     if (optIn && !_hasAnnotation(v, jsonProperty)) return;
     var name = propertyNameEncoder(MirrorSystem.getName(k));
     var value = instanceMirror.getField(k).reflectee;
+    if (_hasAnnotation(v, jsonIgnoreNull) && value == null) return;
     map[name] = __objectToJson(value);
   });
 

--- a/test/jsonx_test.dart
+++ b/test/jsonx_test.dart
@@ -55,6 +55,23 @@ class B {
   int b2;
 }
 
+class C {
+  @jsonIgnoreNull
+  int c1;
+
+  int c2;
+}
+
+@jsonObject
+class D {
+  @jsonProperty
+  @jsonIgnoreNull
+  int d1;
+
+  @jsonIgnoreNull
+  int d2;
+}
+
 main() {
   // ------------ set up --------------
 
@@ -237,5 +254,21 @@ main() {
   test('Enums', () {
     expect(encode(Color.red), equals('2'));
     expect(decode('1', type: Color), equals(Color.green));
+  });
+
+  test('ignoreNull without jsonObject', () {
+    var c = new C()
+      ..c1 = null
+      ..c2 = null;
+    expect(encode(c).contains("c1"), isFalse);
+    expect(encode(c).contains("c2"), isTrue);
+  });
+
+  test('ignoreNull with jsonObject', () {
+    var d = new D()
+      ..d1 = null
+      ..d2 = 5;
+    expect(encode(d).contains("d1"), isFalse);
+    expect(encode(d).contains("d2"), isFalse);
   });
 }


### PR DESCRIPTION
Tests included.

The new annotation works for both `@jsonObject` and without.

Fixes #12 
